### PR TITLE
Fix scrapbox en link

### DIFF
--- a/readme_former.md
+++ b/readme_former.md
@@ -18,7 +18,7 @@ https://scrapbox.io/self-made-kbds-ja/SMKiJ_Discord_%23README_%28unofficially_tr
     - キーボードに関する雑談など。投稿チャネルに悩んだらまずはここへ :point_left:
 - PARTS & COLLECTIONS
     - 個別のキーボードのパーツの話題や自慢のコレクションの紹介、Group Buy 情報など :keyboard:
-    - #vendor-announcements では販売業者の方からのスペシャルオファーを提供 ※投稿権限欲しい人は @managers まで
+    - #vendor-announcements では販売業者の方からのスペシャルオファーや IC/GB 情報を提供 ※投稿権限欲しい人は @managers まで
 - DEVELOPMENT
     - キーボードの設計開発に関する話題はこちら :triangular_ruler:
 - CLINIC

--- a/readme_former.md
+++ b/readme_former.md
@@ -25,7 +25,7 @@ https://scrapbox.io/self-made-kbds-ja/SMKiJ_Discord_%23README_%28unofficially_tr
     - トラブルシュートはこちら。利用の前に必ず #clinic-readme🔰 を一度お読みください
 - PROJECT
     - 各種キーボードや開発対象ごとのチャネル :tools:
-    - コミュニティと協調して開発を行いたい、Interest を Check したい、という場合は @managers に申請してもらえればプロジェクトチャネル開設を検討します :person_gesturing_ok: 
+    - コミュニティと協調して開発を行いたい、Interest を Check したい、という場合は @managers に申請してもらえればプロジェクトチャネル開設を検討します :person_gesturing_ok:
     - ARCHIVE 化の判断は随時行います
 - OTHER
     - 直接はキーボードに関係ない話題などはこちら :video_game:

--- a/readme_former.md
+++ b/readme_former.md
@@ -3,7 +3,7 @@
 このサーバーは自作キーボードに興味がある・つくっている・ほしい人たちのコミュニティ活動の場です。
 
 English translated version (unofficial) here:
-https://scrapbox.io/self-made-kbds-ja/SMKiJ_Discord_%23README_(unofficially_translated_from_Japanese)
+https://scrapbox.io/self-made-kbds-ja/SMKiJ_Discord_%23README_%28unofficially_translated_from_Japanese%29
 
 ──────────────────────────────
 


### PR DESCRIPTION
Scrapbox でホストされている英語版 readme のリンクが Android 版の Discord でカッコがパースできなかった。BASE64 エンコードに置き換えて修正。

あわせて `#vendor-announcement` の表現を更新。余計なスペースを削除。

PR 細々してもアレなのでまとめちゃった。